### PR TITLE
chore: use NATIONAL_ID so it can be searched with

### DIFF
--- a/src/api/certificates/source/Farajaland-birth-certificate-v2.svg
+++ b/src/api/certificates/source/Farajaland-birth-certificate-v2.svg
@@ -37,7 +37,7 @@
 <path d="M321.76 715.071L512.079                715.969" stroke="#CCCCCC" stroke-width="0.75879" stroke-dasharray="3.04 1.52"/>
 
 <text fill="#222222" xml:space="preserve" style="white-space: pre" font-family="Noto Sans" font-size="8" font-weight="bold" letter-spacing="0px"><tspan x="80.9999" y="735.552">NID</tspan></text>
-<text fill="#222222" xml:space="preserve" style="white-space: pre" font-family="Noto Sans" font-size="8" letter-spacing="0px"><tspan x="234.289" y="735.552">&#x2028;</tspan><tspan x="80.9999" y="747.552">{{ birthConfigurableIdentifier1 }}</tspan></text>
+<text fill="#222222" xml:space="preserve" style="white-space: pre" font-family="Noto Sans" font-size="8" letter-spacing="0px"><tspan x="234.289" y="735.552">&#x2028;</tspan><tspan x="80.9999" y="747.552">{{ childIdentifier }}</tspan></text>
 
 <text fill="#222222" xml:space="preserve" style="white-space: pre" font-family="Noto Sans" font-size="7.76" font-weight="bold" letter-spacing="0px"><tspan x="357.751" y="728.084">Registrar / L&#39;Officier de l&#39;&#xc9;tat Civil</tspan></text>
 <text fill="#222222" xml:space="preserve" style="white-space: pre" font-family="Noto Sans" font-size="7.76" letter-spacing="0px"><tspan x="391.819" y="740.694">{{registrar.name}}</tspan></text>

--- a/src/form/birth/certificate-handlebars.ts
+++ b/src/form/birth/certificate-handlebars.ts
@@ -24,6 +24,7 @@ export const certificateHandlebars = {
   registrationLocation: 'registrationLocation', // @deprecated use registrar.office/state/district instead
   contactEmail: 'contactEmail',
   contactPhoneNumber: 'contactPhoneNumber',
+  childIdentifier: 'childIdentifier',
   birthConfigurableIdentifier1: 'birthConfigurableIdentifier1',
   birthConfigurableIdentifier2: 'birthConfigurableIdentifier2',
   birthConfigurableIdentifier3: 'birthConfigurableIdentifier3',

--- a/src/utils/mapping/section/birth/mapping-utils.ts
+++ b/src/utils/mapping/section/birth/mapping-utils.ts
@@ -81,6 +81,11 @@ export function getSectionMapping(mappingId: string): ISectionMapping {
       return {
         template: [
           {
+            fieldName: 'childIdentifier',
+            operation: 'childIdentityToFieldTransformer',
+            parameters: [['NATIONAL_ID']]
+          },
+          {
             fieldName: 'birthConfigurableIdentifier1',
             operation: 'childIdentityToFieldTransformer',
             parameters: [['BIRTH_CONFIGURABLE_IDENTIFIER_1']]


### PR DESCRIPTION
Instead of the BIRTH_CONFIGURABLE_IDENTIFIER, lets use NATIONAL_ID so it supports searching by default. IMO this is not ideal as we need custom mapping country-config code, but Events V2 should address this via allowing configuring what can be searched with.