### PR TITLE
Release v1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.8.1
+
+### Improvements
+
+-  Use the Alpine image with the fixed tag `3.22.1` during the backup process
+
 ## 1.8.0
 
 ### New features

--- a/infrastructure/backups/backup.sh
+++ b/infrastructure/backups/backup.sh
@@ -216,7 +216,7 @@ echo "Creating a backup for SQLite"
 docker run --rm \
   -v $ROOT_PATH/sqlite:/data/sqlite \
   -v $ROOT_PATH/backups/sqlite:/data/backup \
-  alpine sh -c "apk add --no-cache sqlite && \
+  alpine:3.22.1 sh -c "apk add --no-cache sqlite && \
   sqlite3 /data/sqlite/mosip-api.db \".backup '/data/backup/mosip-api-${LABEL:-$BACKUP_DATE}.sqlite'\""
 
 #-------------------------------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencrvs/countryconfig",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "OpenCRVS country configuration for reference data",
   "os": [
     "darwin",


### PR DESCRIPTION
## Description
Fixed the tag for alpine image that will prevent the backup error

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
