### PR TITLE
fix: backend doesnt get the full http payload

### DIFF
--- a/src/form/v2/utils.ts
+++ b/src/form/v2/utils.ts
@@ -315,11 +315,7 @@ export const connectToMOSIPVerificationStatus = (
       ...fieldInput,
       conditionals: upsertConditional(fieldInput.conditionals || [], {
         type: ConditionalType.SHOW,
-        conditional: not(
-          field(`${page}.verify-nid-http-fetch`)
-            .get('data.verificationStatus')
-            .isEqualTo('authenticated')
-        )
+        conditional: not(field(`${page}.verified`).isEqualTo('authenticated'))
       })
     }
   }

--- a/src/form/v2/utils.ts
+++ b/src/form/v2/utils.ts
@@ -8,6 +8,7 @@ import {
   field,
   FieldConditional,
   FieldConfigInput,
+  never,
   SelectOption,
   TranslationConfig
 } from '@opencrvs/toolkit/events'
@@ -163,6 +164,12 @@ export const getMOSIPIntegrationFields = (
     {
       id: `${page}.query-params`,
       type: FieldType.QUERY_PARAM_READER,
+      conditionals: [
+        {
+          type: ConditionalType.DISPLAY_ON_REVIEW,
+          conditional: never()
+        }
+      ],
       label: {
         id: 'form.query-params.label',
         defaultMessage: 'Query param reader',
@@ -183,6 +190,12 @@ export const getMOSIPIntegrationFields = (
     {
       id: `${page}.verify-nid-http-fetch`,
       type: FieldType.HTTP,
+      conditionals: [
+        {
+          type: ConditionalType.DISPLAY_ON_REVIEW,
+          conditional: never()
+        }
+      ],
       label: {
         defaultMessage: 'Fetch applicant information',
         description: 'Fetch applicant information',
@@ -223,6 +236,10 @@ export const getMOSIPIntegrationFields = (
           conditional: not(
             field(`${page}.verify-nid-http-fetch`).get('loading').isFalsy()
           )
+        },
+        {
+          type: ConditionalType.DISPLAY_ON_REVIEW,
+          conditional: never()
         }
       ],
       label: {


### PR DESCRIPTION
> [!NOTE]
> Currently, we do **not** run e2e tests as a check on `opencrvs-countryconfig`-repo PRs. Please ensure your PR doesn't break any e2e tests.
>
> One method for doing this is to open a PR with these changes to `opencrvs-farajaland` as well, and see if the PR check passes there.

## Description

Fixes the backend validation failing as it doesn't get the full http fetch status
Fixes review showing query params & http field

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
