### PR TITLE
bumps mosip-api to 1.9.0-beta.4 and fetches nid & id type

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@hapi/boom": "^9.1.1",
     "@hapi/hapi": "^20.0.1",
     "@hapi/inert": "^6.0.3",
-    "@opencrvs/mosip": "1.9.0-beta.3",
+    "@opencrvs/mosip": "1.9.0-beta.4",
     "@opencrvs/toolkit": "1.8.1-rc.a080254",
     "@types/chalk": "^2.2.0",
     "@types/csv2json": "^1.4.0",

--- a/src/form/v2/birth/forms/pages/father.ts
+++ b/src/form/v2/birth/forms/pages/father.ts
@@ -265,7 +265,7 @@ export const father = defineFormPage({
       ],
       defaultValue: 'FAR'
     },
-    connectToMOSIPVerificationStatus(
+    connectToMOSIPIdReader(
       {
         id: 'father.idType',
         type: FieldType.SELECT,
@@ -283,9 +283,9 @@ export const father = defineFormPage({
           }
         ]
       },
-      { hideIfAuthenticated: true }
+      { valuePath: 'data.idType', hideIfAuthenticated: true }
     ),
-    connectToMOSIPVerificationStatus(
+    connectToMOSIPIdReader(
       {
         id: 'father.nid',
         type: FieldType.ID,
@@ -319,7 +319,7 @@ export const father = defineFormPage({
           }
         ]
       },
-      { hideIfAuthenticated: true }
+      { valuePath: 'data.nid', hideIfAuthenticated: true }
     ),
     {
       id: 'father.passport',

--- a/src/form/v2/birth/forms/pages/informant.ts
+++ b/src/form/v2/birth/forms/pages/informant.ts
@@ -305,7 +305,7 @@ export const informant = defineFormPage({
       defaultValue: 'FAR',
       parent: field('informant.relation')
     },
-    connectToMOSIPVerificationStatus(
+    connectToMOSIPIdReader(
       {
         id: 'informant.idType',
         type: FieldType.SELECT,
@@ -324,9 +324,9 @@ export const informant = defineFormPage({
         ],
         parent: field('informant.relation')
       },
-      { hideIfAuthenticated: true }
+      { valuePath: 'data.idType', hideIfAuthenticated: true }
     ),
-    connectToMOSIPVerificationStatus(
+    connectToMOSIPIdReader(
       {
         id: 'informant.nid',
         type: FieldType.ID,
@@ -361,7 +361,7 @@ export const informant = defineFormPage({
         ],
         parent: field('informant.relation')
       },
-      { hideIfAuthenticated: true }
+      { valuePath: 'data.nid', hideIfAuthenticated: true }
     ),
     {
       id: 'informant.passport',

--- a/src/form/v2/birth/forms/pages/informant.ts
+++ b/src/form/v2/birth/forms/pages/informant.ts
@@ -358,8 +358,7 @@ export const informant = defineFormPage({
               not(field('informant.nid').isEqualTo(field('father.nid')))
             )
           }
-        ],
-        parent: field('informant.relation')
+        ]
       },
       { valuePath: 'data.nid', hideIfAuthenticated: true }
     ),

--- a/src/form/v2/birth/forms/pages/informant.ts
+++ b/src/form/v2/birth/forms/pages/informant.ts
@@ -321,8 +321,7 @@ export const informant = defineFormPage({
             type: ConditionalType.SHOW,
             conditional: informantOtherThanParent
           }
-        ],
-        parent: field('informant.relation')
+        ]
       },
       { valuePath: 'data.idType', hideIfAuthenticated: true }
     ),

--- a/src/form/v2/birth/forms/pages/mother.ts
+++ b/src/form/v2/birth/forms/pages/mother.ts
@@ -262,7 +262,7 @@ export const mother = defineFormPage({
       ],
       defaultValue: 'FAR'
     },
-    connectToMOSIPVerificationStatus(
+    connectToMOSIPIdReader(
       {
         id: 'mother.idType',
         type: FieldType.SELECT,
@@ -280,9 +280,9 @@ export const mother = defineFormPage({
           }
         ]
       },
-      { hideIfAuthenticated: true }
+      { valuePath: 'data.idType', hideIfAuthenticated: true }
     ),
-    connectToMOSIPVerificationStatus(
+    connectToMOSIPIdReader(
       {
         id: 'mother.nid',
         type: FieldType.ID,
@@ -316,7 +316,7 @@ export const mother = defineFormPage({
           }
         ]
       },
-      { hideIfAuthenticated: true }
+      { valuePath: 'data.nid', hideIfAuthenticated: true }
     ),
     {
       id: 'mother.passport',

--- a/src/form/v2/death/forms/pages/deceased.ts
+++ b/src/form/v2/death/forms/pages/deceased.ts
@@ -217,7 +217,7 @@ export const deceased = defineFormPage({
       },
       defaultValue: 'FAR'
     },
-    connectToMOSIPVerificationStatus(
+    connectToMOSIPIdReader(
       {
         id: `deceased.idType`,
         type: FieldType.SELECT,
@@ -229,9 +229,9 @@ export const deceased = defineFormPage({
         },
         options: idTypeOptions
       },
-      { hideIfAuthenticated: true }
+      { valuePath: 'data.idType', hideIfAuthenticated: true }
     ),
-    connectToMOSIPVerificationStatus(
+    connectToMOSIPIdReader(
       {
         id: 'deceased.nid',
         type: FieldType.ID,
@@ -261,7 +261,7 @@ export const deceased = defineFormPage({
           }
         ]
       },
-      { hideIfAuthenticated: true }
+      { valuePath: 'data.nid', hideIfAuthenticated: true }
     ),
     {
       id: `deceased.passport`,

--- a/src/form/v2/death/forms/pages/informant.ts
+++ b/src/form/v2/death/forms/pages/informant.ts
@@ -304,7 +304,7 @@ export const informant = defineFormPage({
       defaultValue: 'FAR',
       parent: field('informant.relation')
     },
-    connectToMOSIPVerificationStatus(
+    connectToMOSIPIdReader(
       {
         id: 'informant.idType',
         type: FieldType.SELECT,
@@ -323,9 +323,9 @@ export const informant = defineFormPage({
         ],
         parent: field('informant.relation')
       },
-      { hideIfAuthenticated: true }
+      { valuePath: 'data.idType', hideIfAuthenticated: true }
     ),
-    connectToMOSIPVerificationStatus(
+    connectToMOSIPIdReader(
       {
         id: 'informant.nid',
         type: FieldType.ID,
@@ -360,7 +360,7 @@ export const informant = defineFormPage({
         ],
         parent: field('informant.relation')
       },
-      { hideIfAuthenticated: true }
+      { valuePath: 'data.nid', hideIfAuthenticated: true }
     ),
     {
       id: 'informant.passport',

--- a/src/form/v2/death/forms/pages/informant.ts
+++ b/src/form/v2/death/forms/pages/informant.ts
@@ -357,8 +357,7 @@ export const informant = defineFormPage({
               not(field('informant.nid').isEqualTo(field('deceased.nid')))
             )
           }
-        ],
-        parent: field('informant.relation')
+        ]
       },
       { valuePath: 'data.nid', hideIfAuthenticated: true }
     ),

--- a/src/form/v2/death/forms/pages/informant.ts
+++ b/src/form/v2/death/forms/pages/informant.ts
@@ -320,8 +320,7 @@ export const informant = defineFormPage({
             type: ConditionalType.SHOW,
             conditional: informantOtherThanSpouse
           }
-        ],
-        parent: field('informant.relation')
+        ]
       },
       { valuePath: 'data.idType', hideIfAuthenticated: true }
     ),

--- a/src/form/v2/death/forms/pages/spouse.ts
+++ b/src/form/v2/death/forms/pages/spouse.ts
@@ -251,7 +251,7 @@ export const spouse = defineFormPage({
       ],
       defaultValue: 'FAR'
     },
-    connectToMOSIPVerificationStatus(
+    connectToMOSIPIdReader(
       {
         id: 'spouse.idType',
         type: FieldType.SELECT,
@@ -269,9 +269,9 @@ export const spouse = defineFormPage({
           }
         ]
       },
-      { hideIfAuthenticated: true }
+      { valuePath: 'data.idType', hideIfAuthenticated: true }
     ),
-    connectToMOSIPVerificationStatus(
+    connectToMOSIPIdReader(
       {
         id: 'spouse.nid',
         type: FieldType.ID,
@@ -305,7 +305,7 @@ export const spouse = defineFormPage({
           }
         ]
       },
-      { hideIfAuthenticated: true }
+      { valuePath: 'data.nid', hideIfAuthenticated: true }
     ),
     {
       id: 'spouse.passport',

--- a/src/form/v2/mosip.ts
+++ b/src/form/v2/mosip.ts
@@ -11,7 +11,8 @@ import {
   ConditionalType,
   FieldType,
   not,
-  never
+  never,
+  or
 } from '@opencrvs/toolkit/events'
 
 const upsertConditional = (
@@ -224,12 +225,18 @@ export const getMOSIPIntegrationFields = (
           conditional: existingShowConditional?.conditional
             ? and(
                 existingShowConditional?.conditional,
-                field(`${page}.verify-nid-http-fetch`).get('loading').isFalsy(),
-                field(`${page}.verify-nid-http-fetch`).get('data').isFalsy()
+                not(
+                  or(
+                    field(`${page}.verified`).isEqualTo('verified'),
+                    field(`${page}.verified`).isEqualTo('authenticated')
+                  )
+                )
               )
-            : and(
-                field(`${page}.verify-nid-http-fetch`).get('loading').isFalsy(),
-                field(`${page}.verify-nid-http-fetch`).get('data').isFalsy()
+            : not(
+                or(
+                  field(`${page}.verified`).isEqualTo('verified'),
+                  field(`${page}.verified`).isEqualTo('authenticated')
+                )
               )
         },
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -834,15 +834,15 @@
   dependencies:
     "@octokit/openapi-types" "^18.0.0"
 
-"@opencrvs/mosip@1.9.0-beta.3":
-  version "1.9.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@opencrvs/mosip/-/mosip-1.9.0-beta.3.tgz#37394eab3ce5781cbcc665beb038b76905982caa"
-  integrity sha512-2CDQVcbYcEaCgZvV0wuJ9j8bsYcxmHZ8fQL3pDD/1WgrawnWbam9HhdEmrILr0T2Kq6wB/mWRh03jy2WbUoMyQ==
+"@opencrvs/mosip@1.9.0-beta.4":
+  version "1.9.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@opencrvs/mosip/-/mosip-1.9.0-beta.4.tgz#343d5b320e61cf2e9ca78064158413f38380e673"
+  integrity sha512-+ugGwetC3kUv63LFkhTeEND7BtwaXOWEHz9FUJ3Y5h69BgE0VB8eXeDwfrGQEWk55+8RM4JrftAInJlgSCUuTA==
 
-"@opencrvs/toolkit@1.8.1-rc.c8c6227":
-  version "1.8.1-rc.c8c6227"
-  resolved "https://registry.yarnpkg.com/@opencrvs/toolkit/-/toolkit-1.8.1-rc.c8c6227.tgz#bac5a80475c4578e6aa802ae70aa4491872c6008"
-  integrity sha512-RdTYBVgJRc2aSrKuLbDRYpAXu1TOssTra6cTuPwoJV23X48NOWuyrSImHf0PUKyS2puF/6v73G1QYyE5FK38Kg==
+"@opencrvs/toolkit@1.8.1-rc.a080254":
+  version "1.8.1-rc.a080254"
+  resolved "https://registry.yarnpkg.com/@opencrvs/toolkit/-/toolkit-1.8.1-rc.a080254.tgz#dc26b6af38aad5bb48350785b906b1741f793fbe"
+  integrity sha512-WZrTmLsk9BjonmKWkJrVFfqLZ74Y6WRaC9bCB/oBAzw8rD0COHVdcLWHqTlSgaafME6+fJmIfEJi2mKaAeKh/Q==
   dependencies:
     "@trpc/client" "11.4.3"
     "@trpc/server" "11.4.3"


### PR DESCRIPTION
> [!NOTE]
> Currently, we do **not** run e2e tests as a check on `opencrvs-countryconfig`-repo PRs. Please ensure your PR doesn't break any e2e tests.
>
> One method for doing this is to open a PR with these changes to `opencrvs-farajaland` as well, and see if the PR check passes there.

## Description

Bumps mosip-api to 1.9.0-beta.4 and fetches nid & id type

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
